### PR TITLE
Add macOS release build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,9 +220,11 @@ with PW2, PW10 and Voyage) and later ones (**Scribe, Colorsoft and latest
 Paperwhite**) are supported by **MTP** subcommand (tested with PW12). E-Mail based
 delivery should be device agnostic.
 
-At the moment program is built for Windows x64 and Linux x64. That all I have
-access to. It was tested on fresh Windows 11 and KUbuntu 24.04 but should work on
-most 64 bit Windows and Linux supported by current [Go language](https://go.dev/wiki/MinimumRequirements).
+Binaries are provided for Windows x64, Linux x64 and macOS (amd64 and arm64).
+They were tested on Windows 11 and KUbuntu 24.04. macOS build currently only
+supports e-mail synchronization because direct device access (MTP/USB) is not
+implemented yet. All builds should work on systems supported by the current
+[Go language](https://go.dev/wiki/MinimumRequirements).
 
 I tried to structure source code in such a way that it should be easy to port
 to other Windows or Linux architectures and it could be relatively simple to
@@ -234,9 +236,8 @@ Windows build does not require CGO at all, but COM support needs to be validated
 Linux build is using CGO and libmtp (which should also work for Darwin) but USB
 discovery is OS specific and needs to be validated for each platform build.
 
-If you have a need to support something I have no way of supporting - say any
-Macs, take a look at sources and drop a PR. We could work together to
-incorporate your changes.
+If you would like to help implement MTP/USB support on macOS feel free to open a
+pull request.
 
 ### TODO
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -15,7 +15,7 @@ vars:
 
   REF_VER: '{{regexFind "refs/tags/v[0-9]+\\.[0-9]+\\.?[0-9]*[-a-zA-Z0-9+]*" (env "GITHUB_REF")}}'
 
-  TARGET_RELEASES: [linux-amd64, windows-amd64-.exe]
+  TARGET_RELEASES: [linux-amd64, windows-amd64-.exe, darwin-amd64, darwin-arm64]
 
   TATN: {sh: '{{if (env "TERM")}}tput setaf 4{{end}}'}
   TOFF: {sh: '{{if (env "TERM")}}tput sgr0{{end}}'}
@@ -166,24 +166,27 @@ tasks:
     status:
       - test -f '{{.REL_NAME}}.zip'
 
-  # release-for-platform-darwin:
-  #   internal: true
-  #   desc: Builds release for specified platform
-  #   requires:
-  #     vars: [GOOS, GOARCH, SUFFIX]
-  #   label: release-for-platform-darwin-{{.GOOS}}-{{.GOARCH}}
-  #   vars:
-  #     BUILD_DIR: '{{.REL_BUILD_DIR}}_{{.GOOS}}_{{.GOARCH}}'
-  #     REL_NAME: '{{.REL_BUILD_DIR}}/s2k-{{.GOOS}}-{{.GOARCH}}'
-  #   cmds:
-  #     - mkdir -p {{.BUILD_DIR}}
-  #     - defer: rm -rf {{.BUILD_DIR}}
-  #     - task: go-build
-  #       vars: {GOOS: '{{.GOOS}}', GOARCH: '{{.GOARCH}}', FLAGS: 'release', PACKAGE: './cmd/s2k', TARGET: '{{.BUILD_DIR}}/s2k{{.SUFFIX}}'}
-  #     - echo "{{.TATN}}Archiving release \"{{.REL_NAME}}.zip\"{{.TOFF}}"
-  #     - 7z a -r -bd -bso0 -tzip {{.REL_NAME}} ./{{.BUILD_DIR}}/*
-  #   status:
-  #     - test -f '{{.REL_NAME}}.zip'
+  release-for-platform-darwin:
+  internal: true
+     desc: Builds release for specified platform
+     requires:
+       vars: [GOOS, GOARCH, SUFFIX]
+     label: release-for-platform-darwin-{{.GOOS}}-{{.GOARCH}}
+    env:
+      CGO_ENABLED: '0'
+
+     vars:
+       BUILD_DIR: '{{.REL_BUILD_DIR}}_{{.GOOS}}_{{.GOARCH}}'
+       REL_NAME: '{{.REL_BUILD_DIR}}/s2k-{{.GOOS}}-{{.GOARCH}}'
+     cmds:
+       - mkdir -p {{.BUILD_DIR}}
+       - defer: rm -rf {{.BUILD_DIR}}
+       - task: go-build
+         vars: {GOOS: '{{.GOOS}}', GOARCH: '{{.GOARCH}}', FLAGS: 'release', PACKAGE: './cmd/s2k', TARGET: '{{.BUILD_DIR}}/s2k{{.SUFFIX}}'}
+       - echo "{{.TATN}}Archiving release \"{{.REL_NAME}}.zip\"{{.TOFF}}"
+       - 7z a -r -bd -bso0 -tzip {{.REL_NAME}} ./{{.BUILD_DIR}}/*
+     status:
+       - test -f '{{.REL_NAME}}.zip'
 
   lint:
     desc: Lints the whole project

--- a/mtp/device_darwin.go
+++ b/mtp/device_darwin.go
@@ -1,0 +1,26 @@
+package mtp
+
+import (
+	"errors"
+	"go.uber.org/zap"
+	"sync2kindle/objects"
+)
+
+// Device stub for macOS.
+type Device struct{}
+
+// Connect returns an error indicating MTP is not supported on macOS.
+func Connect(paths, serial string, verbose bool, _ *zap.Logger) (*Device, error) {
+	return nil, errors.New("MTP support not implemented on darwin")
+}
+
+// Stub implementations to satisfy driver interface.
+func (d *Device) Disconnect()                      {}
+func (d *Device) Name() string                     { return driverName }
+func (d *Device) UniqueID() string                 { return "" }
+func (d *Device) MkDir(*objects.ObjectInfo) error  { return errors.New("not supported") }
+func (d *Device) Remove(*objects.ObjectInfo) error { return errors.New("not supported") }
+func (d *Device) Copy(*objects.ObjectInfo) error   { return errors.New("not supported") }
+func (d *Device) GetObjectInfos() (objects.ObjectInfoSet, error) {
+	return nil, errors.New("not supported")
+}

--- a/objects/obj_darwin.go
+++ b/objects/obj_darwin.go
@@ -1,0 +1,43 @@
+package objects
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const prefix = "o"
+
+type ObjectID uint32
+
+// fmt.Stringer
+func (p ObjectID) String() string {
+	return fmt.Sprintf(prefix+"%X", uint32(p))
+}
+
+// For convinience marshal ObjectID as a string, rather than []uint16
+func (p *ObjectID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.String())
+}
+
+// For convinience unmarshal ObjectID from a string, rather than []uint16
+func (p *ObjectID) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	if len(s) > 0 {
+		s := strings.TrimPrefix(s, prefix)
+
+		// special case to be able to run Windows test datasets on Linux
+		s = strings.TrimPrefix(s, "s")
+
+		d, err := strconv.ParseUint(s, 16, 32)
+		if err != nil {
+			return err
+		}
+		*p = ObjectID(d)
+	}
+	return nil
+}

--- a/usbms/device_darwin.go
+++ b/usbms/device_darwin.go
@@ -1,0 +1,26 @@
+package usbms
+
+import (
+	"errors"
+
+	"go.uber.org/zap"
+	"sync2kindle/objects"
+)
+
+type Device struct{}
+
+// Connect to the supported device. Currently not implemented for macOS.
+func Connect(paths, serial string, eject bool, _ *zap.Logger) (*Device, error) {
+	return nil, errors.New("USBMS support not implemented on darwin")
+}
+
+// Stub implementations to satisfy the driver interface.
+func (d *Device) Disconnect()                      {}
+func (d *Device) Name() string                     { return driverName }
+func (d *Device) UniqueID() string                 { return "" }
+func (d *Device) MkDir(*objects.ObjectInfo) error  { return errors.New("not supported") }
+func (d *Device) Remove(*objects.ObjectInfo) error { return errors.New("not supported") }
+func (d *Device) Copy(*objects.ObjectInfo) error   { return errors.New("not supported") }
+func (d *Device) GetObjectInfos() (objects.ObjectInfoSet, error) {
+	return nil, errors.New("not supported")
+}


### PR DESCRIPTION
## Summary
- add macOS implementations for USBMS and MTP drivers (stubs)
- support Darwin ObjectID type
- update release configuration to include darwin targets
- document macOS binary availability

## Testing
- `GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build ./cmd/s2k`
- `GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build ./cmd/s2k`

------
https://chatgpt.com/codex/tasks/task_e_687be9bfafd4832ebf5bc4844810aad3